### PR TITLE
feat(bot-rest): add bot REST module for sending messages to channels

### DIFF
--- a/src/@type/index.d.ts
+++ b/src/@type/index.d.ts
@@ -1,4 +1,5 @@
 import { ChannelMessageContent, EMarkdownType } from 'mezon-sdk';
+import { EMessageMode } from 'src/common/enums/mezon.enum';
 
 declare global {
   type MezonClientConfig = {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { ConfigModule } from './modules/config/config.module';
 import { MezonModule } from './modules/mezon/mezon.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { BotModule } from './modules/bot/bot.module';
+import { BotModule as BotRestModule } from './modules/bot-rest/bot.module';
 
 @Module({
   imports: [
@@ -81,6 +82,7 @@ import { BotModule } from './modules/bot/bot.module';
     }),
     EventEmitterModule.forRoot(),
     BotModule,
+    BotRestModule,
   ],
 })
 export class AppModule {}

--- a/src/common/enums/mezon.enum.ts
+++ b/src/common/enums/mezon.enum.ts
@@ -18,3 +18,9 @@ export declare enum EMessageSelectType {
   ROLE = 3,
   CHANNEL = 4,
 }
+
+export enum EMessageMode {
+  CHANNEL_MESSAGE = 2,
+  DM_MESSAGE = 4,
+  THREAD_MESSAGE = 6,
+}

--- a/src/modules/bot-rest/bot.controller.ts
+++ b/src/modules/bot-rest/bot.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+  ApiBody,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { BotService } from './bot.service';
+import { SendMessageDto } from './dto/send-message.dto';
+@ApiTags('bot')
+@Controller('bot')
+export class BotController {
+  constructor(private readonly botService: BotService) {}
+
+  @Post('send-message-to-channel')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Send message to channel',
+    description: 'Sends a message to a specified channel with markdown support',
+  })
+  @ApiBody({ type: SendMessageDto })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Message successfully sent to the channel',
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Unauthorized access',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid input parameters',
+  })
+  async sendMessageToChannel(
+    @Body() messageData: SendMessageDto,
+  ): Promise<void> {
+    await this.botService.sendMessage(messageData);
+  }
+}

--- a/src/modules/bot-rest/bot.module.ts
+++ b/src/modules/bot-rest/bot.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MezonUser } from '../mezon/domain/entities/mezon-users.entity';
+import { Channel } from '../mezon/domain/entities/channel.entity';
+import { BotService } from './bot.service';
+import { BotController } from './bot.controller';
+@Module({
+  imports: [TypeOrmModule.forFeature([MezonUser, Channel])],
+  providers: [BotService],
+  controllers: [BotController],
+  exports: [BotService],
+})
+export class BotModule {}

--- a/src/modules/bot-rest/bot.service.ts
+++ b/src/modules/bot-rest/bot.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { MezonService } from '../mezon/mezon.service';
+import { Repository } from 'typeorm';
+import { MezonUser } from '../mezon/domain/entities/mezon-users.entity';
+import { Channel } from '../mezon/domain/entities/channel.entity';
+import { generateChannelMessageContent } from 'src/common/utils/message';
+import { EMarkdownType } from 'mezon-sdk';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class BotService {
+  private readonly logger = new Logger(BotService.name);
+
+  constructor(
+    private readonly mezonService: MezonService,
+    @InjectRepository(MezonUser)
+    private readonly usersRepository: Repository<MezonUser>,
+    @InjectRepository(Channel)
+    private readonly channelsRepository: Repository<Channel>,
+  ) {}
+
+  sendMessage({
+    channelId,
+    message,
+    markdownType,
+  }: {
+    message: string;
+    channelId: string;
+    markdownType?: EMarkdownType;
+  }) {
+    this.channelsRepository
+      .findOne({
+        where: { channelId },
+      })
+      .then(channel => {
+        if (!channel) {
+          this.logger.error(`Channel ${channelId} not found`);
+          return;
+        }
+
+        this.mezonService.sendMessage({
+          clan_id: channel.clanId,
+          channel_id: channel.channelId,
+          is_public: channel.isPublic,
+          mode: channel.type,
+          msg: generateChannelMessageContent({
+            message,
+            blockMessage: markdownType === EMarkdownType.TRIPLE,
+          }),
+          ref: [],
+        });
+      });
+  }
+}

--- a/src/modules/bot-rest/dto/send-message.dto.ts
+++ b/src/modules/bot-rest/dto/send-message.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsEnum } from 'class-validator';
+import { EMarkdownType } from 'mezon-sdk';
+
+export class SendMessageDto {
+  @ApiProperty({
+    description: 'Channel ID where the message will be sent',
+    example: '987654321',
+  })
+  @IsString()
+  @IsNotEmpty()
+  channelId: string;
+
+  @ApiProperty({
+    description: 'MarkdownType',
+    enum: EMarkdownType,
+    example: EMarkdownType.SINGLE,
+  })
+  @IsNotEmpty()
+  @IsEnum(EMarkdownType)
+  markdownType: EMarkdownType;
+
+  @ApiProperty({
+    description: 'Message content',
+    example: 'Hello, this is a message from the bot!',
+  })
+  @IsNotEmpty()
+  @IsString()
+  message: string;
+}

--- a/src/modules/bot/bot.module.ts
+++ b/src/modules/bot/bot.module.ts
@@ -4,8 +4,12 @@ import { BotGateway } from './bot.gateway';
 import { EventListenerChannelMessage } from './listeners/channel-message.lissten';
 import { Asterisk } from './asterisk-commands/asterisk';
 import { HelpCommand } from './asterisk-commands/commands';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Channel } from '../mezon/domain/entities/channel.entity';
+import { MezonUser } from '../mezon/domain/entities/mezon-users.entity';
+
 @Module({
-  imports: [MezonModule],
+  imports: [MezonModule, TypeOrmModule.forFeature([Channel, MezonUser])],
   providers: [BotGateway, EventListenerChannelMessage, Asterisk, HelpCommand],
   exports: [BotGateway],
 })

--- a/src/modules/mezon/domain/entities/channel.entity.ts
+++ b/src/modules/mezon/domain/entities/channel.entity.ts
@@ -1,0 +1,51 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { BaseEntity } from '../../../../common/base.entity';
+import { Exclude } from 'class-transformer';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { EMessageMode } from '../../../../common/enums/mezon.enum';
+
+@Entity('channels')
+export class Channel extends BaseEntity {
+  @PrimaryColumn({ type: 'text' })
+  @IsNotEmpty()
+  @IsString()
+  channelId: string;
+
+  @Column({ type: 'text' })
+  @IsString()
+  clanId: string;
+
+  @Column({
+    type: 'text',
+    nullable: true,
+  })
+  @Exclude()
+  @IsOptional()
+  @IsString()
+  name: string;
+
+  @Column({
+    type: 'enum',
+    enum: EMessageMode,
+    nullable: true,
+  })
+  @Exclude()
+  @IsOptional()
+  type: EMessageMode;
+
+  @Column({
+    type: 'boolean',
+    default: true,
+  })
+  @Exclude()
+  @IsBoolean()
+  isActive: boolean;
+
+  @Column({
+    type: 'boolean',
+    default: false,
+  })
+  @Exclude()
+  @IsBoolean()
+  isPublic: boolean;
+}

--- a/src/modules/mezon/domain/entities/mezon-users.entity.ts
+++ b/src/modules/mezon/domain/entities/mezon-users.entity.ts
@@ -1,0 +1,44 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+import { BaseEntity } from '../../../../common/base.entity';
+import { Exclude } from 'class-transformer';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+} from 'class-validator';
+@Entity('mezon_users')
+@Index(['userId', 'email'])
+export class MezonUser extends BaseEntity {
+  @PrimaryColumn()
+  @Exclude()
+  @Index()
+  @IsNotEmpty()
+  userId: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  @IsString()
+  @IsOptional()
+  username: string;
+
+  @Column({
+    type: 'varchar',
+    length: 100,
+    nullable: true,
+    name: 'display_name',
+  })
+  @IsString()
+  @IsOptional()
+  display_name: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  @IsUrl()
+  @IsOptional()
+  avatar: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true, unique: true })
+  @IsEmail()
+  @IsOptional()
+  email: string;
+}

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -22,6 +22,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @ApiTags('users')
 @Controller('users')
+@ApiBearerAuth()
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
@@ -38,7 +39,6 @@ export class UsersController {
 
   @Get()
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get all users' })
   @ApiResponse({
     status: 200,
@@ -51,7 +51,6 @@ export class UsersController {
 
   @Get(':id')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Get user by ID' })
   @ApiResponse({
     status: 200,
@@ -65,7 +64,6 @@ export class UsersController {
 
   @Patch(':id')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Update user' })
   @ApiResponse({
     status: 200,
@@ -82,7 +80,6 @@ export class UsersController {
 
   @Delete(':id')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Delete user' })
   @ApiResponse({ status: 200, description: 'User deleted successfully' })
   @ApiResponse({ status: 404, description: 'User not found' })


### PR DESCRIPTION
This commit introduces a new REST module for the bot, enabling the ability to send messages to channels via REST API. It includes the necessary controllers, services, and DTOs for handling message sending, along with TypeORM entities for managing channels and users. The module is integrated into the main application module, and the existing bot module is updated to support TypeORM for channel management.