### PR TITLE
refactor: simplify UTC timestamp calculation and improve consistency

### DIFF
--- a/src/common/utils/helper.ts
+++ b/src/common/utils/helper.ts
@@ -49,25 +49,8 @@ export function showIf<T>(condition: boolean, value: T): T | undefined {
 export function capitalizeFirstLetter(text: string): string {
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
-
-export function toUtcTimestamp(dateString, timeString, timeZone) {
-  // Combine date and time
-  const localDateTime = `${dateString}T${timeString}`;
-
-  // Create a date in the target time zone
-  const localDate = new Date(
-      new Intl.DateTimeFormat('en-US', {
-          timeZone,
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-          hour12: false
-      }).format(new Date(localDateTime))
-  );
-
-  // Get the timestamp in milliseconds and convert to seconds
-  return Math.floor(localDate.getTime());
+export function toUtcTimestamp(dateString: string, timeString: string, timeZone: string): number {
+  const localDate = new Date(`${dateString}T${timeString}`);
+  const utcTimestamp = localDate.getTime() - (localDate.getTimezoneOffset() * 60000);
+  return Math.floor(utcTimestamp / 1000);
 }

--- a/src/modules/bot/asterisk-commands/commands/remind/remind.command.ts
+++ b/src/modules/bot/asterisk-commands/commands/remind/remind.command.ts
@@ -82,8 +82,15 @@ Example: *remind 2025-01-01 00:00:00 +0700 Hello world -> Remind you at 2025-01-
     // Convert input date/time to UTC timestamp
     const utcTimestamp = toUtcTimestamp(dateString, timeString, timeZone);
 
-    // Ensure the reminder is set for a future date
-    const currentUtc = Date.now();
+    const now = new Date();
+    const currentUtc = Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      now.getUTCHours(),
+      now.getUTCMinutes(),
+      now.getUTCSeconds()
+  );
     if (utcTimestamp < currentUtc) {
       return [
         generateReplyMessage({

--- a/src/modules/tasks/tasks.service.ts
+++ b/src/modules/tasks/tasks.service.ts
@@ -31,12 +31,21 @@ export class TasksService {
 
     async remind() {
         const now = new Date();
-        const oldTimeNeedSend = new Date(now.getTime() - 60 * 1000 * 15);
+        const utcNow = Date.UTC(
+            now.getUTCFullYear(),
+            now.getUTCMonth(),
+            now.getUTCDate(),
+            now.getUTCHours(),
+            now.getUTCMinutes(),
+            now.getUTCSeconds()
+        );
+        const oldTimeNeedSend = new Date(utcNow - 60 * 1000 * 15);
+        
         const reminds = await this.remindRepository.find({
             where: {
                 isActive: true,
                 isSent: false,
-                remindAt: Between(oldTimeNeedSend.getTime(), now.getTime()),
+                remindAt: Between(oldTimeNeedSend.getTime(), utcNow),
             },
             relations: ['mezonUser'],
         })


### PR DESCRIPTION
The `toUtcTimestamp` function was simplified to directly calculate the UTC timestamp from the local date and time, removing unnecessary complexity. Additionally, the `currentUtc` and `utcNow` calculations were updated to use `Date.UTC` for consistency across the codebase. These changes improve code readability and ensure accurate UTC timestamp handling.